### PR TITLE
Handle printing 0 to std::ostream

### DIFF
--- a/cuda_uint128.h
+++ b/cuda_uint128.h
@@ -811,10 +811,14 @@ template <typename T>
   {
     std::vector<uint16_t> rout;
     uint64_t v = 10, r = 0;
-    while(x != 0){
+    if (x == 0) {
+      out << "0";
+      return out;
+    }
+    do {
       x = div128to128(x, v, &r);
       rout.push_back(r);
-    }
+    } while(x != 0);
     for(std::reverse_iterator<std::vector<uint16_t>::iterator> rit = rout.rbegin(); rit != rout.rend(); rit++){
       out << *rit;
     }


### PR DESCRIPTION
The algorithm for `friend inline std::ostream & operator<<(std::ostream & out, uint128_t x)` will not print anything if the `x` argument is 0.  I checked to see if glibc does something clever in printf to handle the same situation, and no, it just special-cases 0.