### PR TITLE
Conditionalize #pragma unroll on #ifdef __CUDA_ARCH__

### DIFF
--- a/cuda_uint128.h
+++ b/cuda_uint128.h
@@ -612,7 +612,6 @@ template <typename T>
     res0 = sqrtf(x);
   #else
     res0 = sqrt(x);
-    #pragma unroll
     for(uint16_t i = 0; i < 8; i++)
       res0 = (res0 + x/res0) >> 1;
   #endif
@@ -638,7 +637,9 @@ template <typename T>
     #else
     res0 = std::sqrt(u128_to_float(x));
     #endif
+    #ifdef __CUDA_ARCH__
     #pragma unroll
+    #endif
     for(uint16_t i = 0; i < 8; i++)
       res0 = (res0 + x/res0) >> 1;
 
@@ -657,7 +658,9 @@ template <typename T>
   #else
     res0 = std::cbrt(u128_to_float(x));
   #endif
+  #ifdef __CUDA_ARCH__
     #pragma unroll
+  #endif
     for(uint16_t i = 0; i < 47; i++) // there needs to be an odd number of iterations
                                      // for the case of numbers of the form x^2 - 1
                                      // where this will not converge


### PR DESCRIPTION
If the user specifies `-Xcompiler -Wall`, the `#pragma unroll` lines will create warnings such as this:

    CUDA-uint128/cuda_uint128.h:621:0: warning: ignoring #pragma unroll  [-Wunknown-pragmas]

This patch conditionalizes them all on __CUDA_ARCH__.