### PR TITLE
Add support for pre-Haswell architecture to clz64

### DIFF
--- a/cuda_uint128.h
+++ b/cuda_uint128.h
@@ -365,7 +365,7 @@ template <typename T>
   #elif __GNUC__ || uint128_t_has_builtin(__builtin_clzll)
     res = __builtin_clzll(x);
   #else
-    asm("bsr %1, %0; xor $0x3f, %0" : "=r" (res) : "m" (x));
+    asm("bsr %1, %0\nxor $0x3f, %0" : "=r" (res) : "rm" (x) : "cc", "flags");
   #endif
     return res;
   }


### PR DESCRIPTION
The previous host-side code for clz64 required the ABM / BMI1 instruction set for lzclr; this was introduced in Intel Haswell (2013) or AMD Piledriver (2012).  It would not issue an error on failure.  Since clz64 is in the code path for `std::ostream &operator<<(std::ostream &, uint128_t)`, this makes it possible to even print incorrect numbers.

The new version will use the gcc or clang builtin clzll, if they're available, or else use the widely-available `bsr` instruction.

The return type is changed to agree with the return type of the CUDA `__clzll` and gcc `__builtin_clzll`, to prevent unnecessary sign extensions.

(For the purpose of `uint128_t_has_builtin`, see https://clang.llvm.org/docs/LanguageExtensions.html#feature-checking-macros , and note that I'm not wild about #defining names starting with __ in a file that user code can see.)