### PR TITLE
Use cmath instead of math.h

### DIFF
--- a/cuda_uint128.h
+++ b/cuda_uint128.h
@@ -19,7 +19,7 @@
 #include <iomanip>
 #include <cinttypes>
 #include <cuda.h>
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <vector>
 #include <iterator>


### PR DESCRIPTION
The code refers to std::sqrt and std::cbrt, which are put into the std namespace in cmath, but not math.h.  Currently, cuda.h (indirectly) includes cmath, but there's no need to depend on that.