### PR TITLE
subtraction now handles uint128_t correctly

### DIFF
--- a/cuda_uint128.h
+++ b/cuda_uint128.h
@@ -145,15 +145,24 @@ public:
   #endif
   }
 
-  template <typename T>
 #ifdef __CUDA_ARCH__
   __host__ __device__
 #endif
-  inline uint128_t & operator-=(const T & b)
+  inline uint128_t & operator-=(const uint128_t & b)
   {
-    uint128_t temp = (uint128_t)b;
-    if(lo < temp.lo) hi--;
-    lo -= temp.lo;
+    if(lo < b.lo) hi--;
+    lo -= b.lo;
+    hi -= b.hi;
+    return * this;
+  }
+
+#ifdef __CUDA_ARCH__
+  __host__ __device__
+#endif
+  inline uint128_t & operator-=(const uint64_t & b)
+  {
+    if(lo < b) hi--;
+    lo -= b;
     return * this;
   }
 


### PR DESCRIPTION
operator-=() handled uint128_t incorrectly. The fix was to replace the previous function with the following 2 functions...

#ifdef __CUDA_ARCH__
  __host__ __device__
#endif
  inline uint128_t & operator-=(const uint128_t & b)
  {
    if(lo < b.lo) hi--;
    lo -= b.lo;
    hi -= b.hi;
    return * this;
  }

#ifdef __CUDA_ARCH__
  __host__ __device__
#endif
  inline uint128_t & operator-=(const uint64_t & b)
  {
    if(lo < b) hi--;
    lo -= b;
    return * this;
  }
