### PR TITLE
fixed shift bug

### DIFF
--- a/cuda_uint128.h
+++ b/cuda_uint128.h
@@ -163,10 +163,12 @@ public:
 #endif
   inline uint128_t & operator>>=(const T & b)
   {
-    if (b < 64) {
+    if (b == 0) {
+      return *this;
+    } else if (b < 64) {
       lo = (lo >> b) | (hi << (64-b));
       hi >>= b;
-    } else {
+    } else {        // note that b >= 128 is undefined
       lo = hi >> (b-64);
       hi = 0;
     }
@@ -179,10 +181,12 @@ public:
 #endif
   inline uint128_t & operator<<=(const T & b)
   {
-    if (b < 64) {
+    if (b == 0) {
+      return *this;
+    } else if (b < 64) {
       hi = (hi << b) | (lo >> (64-b));
       lo <<= b;
-    } else {
+    } else {        // note that b >= 128 is undefined
       hi = lo << (b-64);
       lo = 0;
     }


### PR DESCRIPTION
operator>>=() and operator<<=() did not correctly handle a shift of 0 because shifting by 64 is undefined. I have corrected the code here by adding another case for b==0:

    if (b == 0) {
      return *this;
    } else if (b < 64) {
      lo = (lo >> b) | (hi << (64-b));
      hi >>= b;
    } else {        // note that b >= 128 is undefined
      lo = hi >> (b-64);
      hi = 0;
    }

    if (b == 0) {
      return *this;
    } else if (b < 64) {
      hi = (hi << b) | (lo >> (64-b));
      lo <<= b;
    } else {        // note that b >= 128 is undefined
      hi = lo << (b-64);
      lo = 0;
    }
