### PR TITLE
fixed division bug by changing a single line

### DIFF
--- a/cuda_uint128.h
+++ b/cuda_uint128.h
@@ -621,7 +621,7 @@ template <typename T>
       un64 = (x.hi << s) | ((x.lo >> (64 - s)) & (-s >> 31));
       un10 = x.lo << s;
     }else{
-      un64 = x.lo | x.hi;
+      un64 = x.hi;
       un10 = x.lo;
     }
 


### PR DESCRIPTION
Wrong answers are sometimes given from div128to64(). To fix it, I replaced
un64 = x.lo | x.hi;
with
un64 = x.hi;